### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/secret-active-dir-solution.json
+++ b/secret-active-dir-solution.json
@@ -798,7 +798,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Timeout": "7",
                 "Environment": {
                     "Variables": {
@@ -1084,7 +1084,7 @@
                         "Arn"
                     ]
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Environment": {
                     "Variables": {
                         "IAM_EC2_ROLE": {


### PR DESCRIPTION
CloudFormation templates in secure-ad-creds-join-unjoin-domain have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.